### PR TITLE
fixes #1 Dial should be synchronous by default

### DIFF
--- a/CHANGES-v2.adoc
+++ b/CHANGES-v2.adoc
@@ -81,3 +81,18 @@ as Options and a `pipe.GetOpt()` API is used to access them.
 The xstar protocol implicitly retransmits / forwards received messages
 just like the cooked protocol.  The fact that v1 did not do this was
 a bug.
+
+== Dial Now Synchronous
+
+When using vanilla Dialer.Dial(), the calling thread will normally
+be blocked until either a connection is established, or an error
+occurs on this first attempt.  If an error occurs, there will be no
+further retries.  However, the self-healing mode is used for subsequent
+connection attempts.
+
+This mode is intended to facilitate folks who are trying to fix the most
+common connection setup errors.
+
+An option, OptionDialAsynch, can be set on sockets or dialers to restore
+the old behavior, where a dialer will just run in the background
+from the beginning.

--- a/options.go
+++ b/options.go
@@ -183,4 +183,13 @@ const (
 	// OptionHTTPRequest conveys an *http.Request.  This read-only option
 	// only exists for Pipes using websocket connections.
 	OptionHTTPRequest = "HTTP-REQUEST"
+
+	// OptionDialAsynch (used on a Dialer) causes the Dial() operation
+	// to run in the background.  Further, the Dialer will always redial,
+	// even if the first attempt fails.  (Normally dialing is performed
+	// synchronously, so that if the remote peer is unavailable at first
+	// the caller can learn of the error and handle or report it.
+	// Note that mangos v1 behavior is the same as if this option is
+	// set to true.
+	OptionDialAsynch = "DIAL-ASYNCH"
 )

--- a/test/busdevice_test.go
+++ b/test/busdevice_test.go
@@ -54,7 +54,6 @@ func TestBusDevice(t *testing.T) {
 			So(s1, ShouldNotBeNil)
 			defer s1.Close()
 			s1.AddTransport(inproc.NewTransport())
-			So(mangos.Device(s1, s1), ShouldBeNil)
 			So(s1.Listen("inproc://busdevicetest"), ShouldBeNil)
 			// Create the device
 			So(mangos.Device(s1, s1), ShouldBeNil)

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -236,6 +236,7 @@ func (c *T) Dial() bool {
 		options[mangos.OptionTLSConfig] = cliCfg
 	}
 
+	options[mangos.OptionDialAsynch] = true
 	err := c.Sock.DialOptions(c.addr, options)
 	if err != nil {
 		c.Errorf("Dial (%s) failed: %v", c.addr, err)

--- a/test/device_test.go
+++ b/test/device_test.go
@@ -276,20 +276,20 @@ func testDevChain(t *testing.T, addr1 string, addr2 string, addr3 string) {
 		t.Errorf("s[0] Listen: %v", err)
 		return
 	}
-	if err = s[1].Dial(addr2); err != nil {
-		t.Errorf("s[1] Dial: %v", err)
-		return
-	}
 	if err = s[2].Listen(addr2); err != nil {
 		t.Errorf("s[2] Listen: %v", err)
 		return
 	}
-	if err = s[3].Dial(addr3); err != nil {
-		t.Errorf("s[3] Dial: %v", err)
-		return
-	}
 	if err = s[4].Listen(addr3); err != nil {
 		t.Errorf("s[4] Listen: %v", err)
+		return
+	}
+	if err = s[1].Dial(addr2); err != nil {
+		t.Errorf("s[1] Dial: %v", err)
+		return
+	}
+	if err = s[3].Dial(addr3); err != nil {
+		t.Errorf("s[3] Dial: %v", err)
 		return
 	}
 	if err = mangos.Device(s[0], s[1]); err != nil {

--- a/test/reqretry_test.go
+++ b/test/reqretry_test.go
@@ -54,6 +54,8 @@ func TestReqRetry(t *testing.T) {
 
 			err = sockreq.SetOption(mangos.OptionReconnectTime, time.Millisecond*100)
 			So(err, ShouldBeNil)
+			err = sockreq.SetOption(mangos.OptionDialAsynch, true)
+			So(err, ShouldBeNil)
 
 			l, err := sockrep.NewListener(addr, nil)
 			So(err, ShouldBeNil)
@@ -87,9 +89,7 @@ func TestReqRetry(t *testing.T) {
 				m.Free()
 			})
 
-			// Following is skipped for now because of the backout
-			// of e5e6478f44cda1eb8427b590755270e2704a990d
-			SkipConvey("A request is reissued on server re-connect", func() {
+			Convey("A request is reissued on server re-connect", func() {
 
 				rep2, err := rep.NewSocket()
 				So(err, ShouldBeNil)


### PR DESCRIPTION
This makes Dial synchronous, and adds a new option, OptionDialAsynch,
which can be set on a socket or a Dialer to restore the mangos v1
behavior.

We also have fixed bugs in the REQ/REP code, and made it correctly
self-heal "quickly" from a broken socket.  (Basically if our response
pipe disconnects, we can immediately try the request somewhere else.)