### PR TITLE
fixes #4 tlstcp transport busted

### DIFF
--- a/transport/conn.go
+++ b/transport/conn.go
@@ -143,7 +143,7 @@ func NewConnPipe(c net.Conn, proto ProtocolInfo, options map[string]interface{})
 		options: make(map[string]interface{}),
 	}
 
-	p.options[mangos.OptionMaxRecvSize] = int64(0)
+	p.options[mangos.OptionMaxRecvSize] = int(0)
 	p.options[mangos.OptionLocalAddr] = p.c.LocalAddr()
 	p.options[mangos.OptionRemoteAddr] = p.c.RemoteAddr()
 	for n, v := range options {

--- a/transport/tlstcp/tlstcp.go
+++ b/transport/tlstcp/tlstcp.go
@@ -90,6 +90,9 @@ func (o options) configTCP(conn *net.TCPConn) error {
 func newOptions(t *tlsTran) options {
 	o := make(map[string]interface{})
 	o[mangos.OptionTLSConfig] = t.config
+	o[mangos.OptionKeepAlive] = true
+	o[mangos.OptionNoDelay] = true
+	o[mangos.OptionMaxRecvSize] = 0
 	return options(o)
 }
 


### PR DESCRIPTION
Turns out we were setting an int64 value for default instead of int(0).