### PR TITLE
Exclude test files from coverage analysis.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,7 @@
 ignore:
  - perf/*
  - examples/*/*
+ - test/*
+ - *_test.go
 coverage:
  range: 50..85


### PR DESCRIPTION
Logic on this is that we have a lot of cases to test for failures,
which should not occur.  We don't really care about whether that
code is executed, so lets focus on the code that is part of what
applications depend upon.